### PR TITLE
Separate `commitment_signed` batches from interactive tx `commitment_signed`

### DIFF
--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -2940,7 +2940,7 @@ fee changes).
     to the ordering of the commitment transaction (see [BOLT #3](03-transactions.md#transaction-input-and-output-ordering)).
   - if it has not recently received a message from the remote node:
       - SHOULD use `ping` and await the reply `pong` before sending `commitment_signed`.
-  - If there are `N` pending splice transactions:
+  - If there are `N` pending splice transactions (with `N` greater than `0`):
     - MUST send `commitment_signed` for the current channel funding output.
     - MUST send `commitment_signed` for each of the splice transactions.
     - MUST set `batch_size` to `N + 1` in every `commitment_signed` message.
@@ -2963,6 +2963,8 @@ A receiving node:
   - If there are pending splice transactions and `batch` is not set:
     - MUST send an `error` and fail the channel.
   - If `batch` is set:
+    - If `batch` is smaller than or equal to `1`:
+      - MUST send an `error` and fail the channel.
     - MUST wait until it has received `batch_size` messages.
     - If there are pending splice transactions:
       - MUST validate each `commitment_signed` based on `funding_txid`.

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -3260,6 +3260,13 @@ The sending node:
         - MUST set `my_current_funding_locked` to the txid of the channel funding transaction.
       - otherwise (it has never sent `channel_ready` or `splice_locked`):
         - MUST NOT set `my_current_funding_locked`.
+      - if `my_current_funding_locked` is included and `announce_channel` is set for this channel:
+        - if it has not received `announcement_signatures` for that transaction:
+          - MUST retransmit `channel_ready` or `splice_locked` after `channel_reestablish`.
+        - if it receives `channel_ready` for that transaction after `channel_reestablish`:
+          - MUST retransmit `channel_ready` in response, if not already sent.
+        - if it receives `splice_locked` for that transaction after `channel_reestablish`:
+          - MUST retransmit `splice_locked` in response, if not already sent.
 
 A node:
   - if `next_commitment_number` is 1 in both the `channel_reestablish` it

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1673,6 +1673,15 @@ The receiving node:
   - Otherwise (it rejects the splice):
     - MUST respond with `tx_abort`.
 
+#### Rationale
+
+When using `option_zeroconf`, nodes may want to wait for the splice transaction
+to be published before sending `splice_locked`. This can be useful when using
+`bitcoind`, which will properly lock the transaction inputs only once it has
+published that transaction, and thus won't double-spend itself. There is no
+reason to reject starting another splice negotiation while this is ongoing, so
+we allow sending `splice_init` before `splice_locked` has been received.
+
 ### The `splice_ack` Message
 
 1. type: 81 (`splice_ack`)
@@ -1866,6 +1875,7 @@ The sending node:
   - MUST NOT send `tx_init_rbf` if it is not the quiescence initiator.
   - MAY send `tx_init_rbf` even if it is not the splice initiator.
   - MUST NOT send `tx_init_rbf` if it has previously sent `splice_locked`.
+  - MUST NOT send `tx_init_rbf` is `option_zeroconf` has been negotiated.
   - MAY set `funding_output_contribution` to a different value than the
     `funding_contribution_satoshis` used in `splice_init` or `splice_ack`,
     or in previous RBF attempts.
@@ -1878,6 +1888,9 @@ The receiving node:
     - MUST send a `warning` and close the connection or send an `error`
       and fail the channel.
   - If the sender previously sent `splice_locked`:
+    - MUST send a `warning` and close the connection or send an `error`
+      and fail the channel.
+  - If `option_zeroconf` has been negotiated:
     - MUST send a `warning` and close the connection or send an `error`
       and fail the channel.
   - If `funding_output_contribution` is negative and its absolute value is
@@ -1935,6 +1948,21 @@ signatures for each of these commitment transactions.
                       +---------------+        +-----------+
 ```
 
+If `option_zeroconf` has been negotiated, splice transactions cannot be RBF-ed,
+but there can be a chain of splice transactions spending each other instead:
+
+```
++------------+        +-----------+
+| Funding Tx |---+--->| Commit Tx |
++------------+   |    +-----------+
+                 |    +-----------+        +-----------+
+                 +--->| Splice Tx |---+--->| Commit Tx |
+                      +-----------+   |    +-----------+
+                                      |    +-----------+        +-----------+
+                                      +--->| Splice Tx |------->| Commit Tx |
+                                           +-----------+        +-----------+
+```
+
 The splice completes by exchanging `splice_locked` messages, at which point
 the locked transaction replaces the previous funding transaction.
 
@@ -1951,13 +1979,46 @@ Each node:
   - If any splice transaction reaches acceptable depth:
     - MUST send `splice_locked` with the `txid` of that transaction.
 
+The receiving node:
+  - If `splice_txid` doesn't match any of its pending splice transactions:
+    - MUST ignore the message.
+  - Otherwise, must treat this `splice_txid` and all of its ancestors as
+    locked by the sending node. 
+
 Once a node has sent and received `splice_locked`:
-  - MUST consider the locked splice transaction to be the new funding
-    transaction for all future `commitment_signed` messages and splice
-    negotiations.
-  - SHOULD discard the previous funding transaction and RBF attempts.
-  - MUST send `announcement_signatures` with `short_channel_id` matching
-    the locked splice transaction.
+  - If the `splice_txid`s match:
+    - MUST stop sending `commitment_signed` for RBF attempts and ancestors
+      of this splice transaction.
+    - MAY discard RBF attempts and ancestor transactions.
+    - MUST send `announcement_signatures` with `short_channel_id` matching
+      this splice transaction.
+  - When `option_zeroconf` has been negotiated, if one of the `splice_txid`s
+    is an ancestor of the other `splice_txid`:
+    - MUST consider this ancestor transaction as locked.
+    - MUST stop sending `commitment_signed` for ancestors of this ancestor
+      transaction.
+    - MAY discard ancestors of this ancestor transaction.
+    - SHOULD send `announcement_signatures` with `short_channel_id` matching
+      this ancestor transaction.
+  - If the `splice_txid`s are for different RBF candidates:
+    - SHOULD ignore the message.
+    - MAY send an `error` and fail the channel.
+
+##### Rationale
+
+When `option_zeroconf` has been negotiated, nodes can create chains of splice
+transactions and may receive `splice_locked` for a splice transaction that is
+not the most recent one. That's fine, it means that we can already lock and
+discard all ancestor transactions, and `splice_locked` for the latest splice
+transaction will be exchanged next and nodes will eventually converge to the
+latest splice transaction.
+
+If nodes are on a different fork of the blockchain, they may disagree on which
+RBF attempt has been confirmed: in that case nodes can either close the channel
+or simply ignore `splice_locked` and wait for one of the forks to eventually
+replace the other, at which point both nodes should agree on which RBF attempt
+confirmed and exchange `splice_locked` for the same `splice_txid` to complete
+the splice.
 
 ## Channel Close
 

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -3296,8 +3296,6 @@ A node:
         message before sending any other messages for that channel.
 
 The sending node:
-  - MUST set `next_commitment_number` to the commitment number of the
-  next `commitment_signed` it expects to receive.
   - MUST set `next_revocation_number` to the commitment number of the
   next `revoke_and_ack` message it expects to receive.
   - MUST set `my_current_per_commitment_point` to a valid point.
@@ -3312,6 +3310,8 @@ The sending node:
       - MUST set `next_commitment_number` to the commitment number of the `commitment_signed` it sent.
   - otherwise:
     - MUST NOT set `next_funding_txid`.
+    - MUST set `next_commitment_number` to the commitment number of the
+    next `commitment_signed` batch it expects to receive.
   - if `option_splice` was negotiated:
     - MUST set `your_last_funding_locked` to the txid of the last `splice_locked` it received.
     - if it never received `splice_locked` for any transaction, but it received `channel_ready`:
@@ -3347,25 +3347,34 @@ A node:
       a different `short_channel_id` `alias` field.
   - upon reconnection:
     - MUST ignore any redundant `channel_ready` it receives.
-  - if `next_commitment_number` is equal to the commitment number of
-  the last `commitment_signed` message the receiving node has sent:
-    - MUST reuse the same commitment number for its next `commitment_signed`.
+  - if it has received `next_funding_txid`:
+    - if `next_commitment_number` matches the last `commitment_signed` message
+    that was already sent for the latest interactive transaction construction:
+      - MUST retransmit `commitment_signed` for the latest interactive
+      transaction construction.
+      - MUST use `next_commitment_number` + 1 for its next `commitment_signed`
+      batch.
   - otherwise:
-    - if `next_commitment_number` is not 1 greater than the
-  commitment number of the last `commitment_signed` message the receiving
-  node has sent:
-      - SHOULD send an `error` and fail the channel.
-    - if it has not sent `commitment_signed`, AND `next_commitment_number`
-    is not equal to 1:
-      - SHOULD send an `error` and fail the channel.
+    - if `next_commitment_number` is equal to the commitment number of
+    the last `commitment_signed` message batch the receiving node has sent:
+      - MUST reuse the same commitment number for its next `commitment_signed`
+      batch.
+    - otherwise:
+      - if `next_commitment_number` is not 1 greater than the
+    commitment number of the last `commitment_signed` message batch the
+    receiving node has sent:
+        - SHOULD send an `error` and fail the channel.
+      - if it has not sent the `commitment_signed` batch, AND
+      `next_commitment_number` is not equal to 1:
+        - SHOULD send an `error` and fail the channel.
   - if `next_revocation_number` is equal to the commitment number of
   the last `revoke_and_ack` the receiving node sent, AND the receiving node
   hasn't already received a `closing_signed`:
     - MUST re-send the `revoke_and_ack`.
-    - if it has previously sent a `commitment_signed` that needs to be
+    - if it has previously sent a `commitment_signed` bacth that needs to be
     retransmitted:
-      - MUST retransmit `revoke_and_ack` and `commitment_signed` in the same
-      relative order as initially transmitted.
+      - MUST retransmit `revoke_and_ack` and `commitment_signed` batch in the
+      same relative order as initially transmitted.
   - otherwise:
     - if `next_revocation_number` is not equal to 1 greater than the
     commitment number of the last `revoke_and_ack` the receiving node has sent:
@@ -3465,7 +3474,7 @@ by the remote node.
 Note that the `next_commitment_number` starts at 1, since
 commitment number 0 is created during opening.
 `next_revocation_number` will be 0 until the
-`commitment_signed` for commitment number 1 is send and then
+`commitment_signed` batch for commitment number 1 is send and then
 the revocation for commitment number 0 is received.
 
 `channel_ready` is implicitly acknowledged by the start of normal

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1630,8 +1630,12 @@ The sending node:
   - MUST NOT send `splice_init` if it is not the quiescence initiator.
   - MUST NOT send `splice_init` before sending and receiving `channel_ready`.
   - MUST NOT send `splice_init` while another splice is being negotiated.
-  - MUST NOT send `splice_init` if another splice has been negotiated but
-    `splice_locked` has not been sent and received.
+  - If `option_zeroconf` has been negotiated:
+    - MAY send `splice_init` before sending and receiving `splice_locked` for
+      the last splice to initiate a new splice spending the last one.
+  - Otherwise:
+    - MUST NOT send `splice_init` if another splice has been negotiated but
+      `splice_locked` has not been sent and received.
   - MUST NOT send `splice_init` if it has previously sent `shutdown`.
   - If it is splicing funds out of the channel:
     - MUST set `funding_contribution_satoshis` to a negative value matching

--- a/02-peer-protocol.md
+++ b/02-peer-protocol.md
@@ -1875,7 +1875,7 @@ The sending node:
   - MUST NOT send `tx_init_rbf` if it is not the quiescence initiator.
   - MAY send `tx_init_rbf` even if it is not the splice initiator.
   - MUST NOT send `tx_init_rbf` if it has previously sent `splice_locked`.
-  - MUST NOT send `tx_init_rbf` is `option_zeroconf` has been negotiated.
+  - MUST NOT send `tx_init_rbf` if `option_zeroconf` has been negotiated.
   - MAY set `funding_output_contribution` to a different value than the
     `funding_contribution_satoshis` used in `splice_init` or `splice_ack`,
     or in previous RBF attempts.

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -84,8 +84,10 @@ matching an endpoint's `node_id` and `bitcoin_key`.
 
 A node:
   - If the `open_channel` message has the `announce_channel` bit set AND a `shutdown` message has not been sent:
-    - After `channel_ready` has been sent and received AND the funding transaction has enough confirmations to ensure that it won't be reorganized:
-      - MUST send `announcement_signatures` for the funding transaction.
+    - MUST NOT send `announcement_signatures` until `channel_ready` or `splice_locked` has been sent and received for that transaction.
+    - MUST NOT send `announcement_signatures` until the funding transaction has enough confirmations to ensure that it won't be reorganized.
+    - Otherwise:
+      - MUST send the `announcement_signatures` message.
   - Otherwise:
     - MUST NOT send the `announcement_signatures` message.
   - Upon reconnection (once the above timing requirements have been met):

--- a/07-routing-gossip.md
+++ b/07-routing-gossip.md
@@ -84,10 +84,10 @@ matching an endpoint's `node_id` and `bitcoin_key`.
 
 A node:
   - If the `open_channel` message has the `announce_channel` bit set AND a `shutdown` message has not been sent:
-    - MUST NOT send `announcement_signatures` until `channel_ready` or `splice_locked` has been sent and received for that transaction.
-    - MUST NOT send `announcement_signatures` until the funding transaction has enough confirmations to ensure that it won't be reorganized.
-    - Otherwise:
-      - MUST send the `announcement_signatures` message.
+    - After `channel_ready` has been sent and received AND the funding transaction has enough confirmations to ensure that it won't be reorganized:
+      - MUST send `announcement_signatures` for the funding transaction.
+    - After `splice_locked` has been sent and received AND the splice transaction has enough confirmations to ensure that it won't be reorganized:
+      - MUST send `announcement_signatures` for the matching splice transaction.
   - Otherwise:
     - MUST NOT send the `announcement_signatures` message.
   - Upon reconnection (once the above timing requirements have been met):
@@ -95,25 +95,35 @@ A node:
       - MUST send its own `announcement_signatures` message.
     - If it receives `announcement_signatures` for the funding transaction:
       - MUST respond with its own `announcement_signatures` message.
+    - If it has NOT previously received `announcement_signatures` for a splice transaction:
+      - MUST retransmit `splice_locked` for that splice transaction.
+      - After receiving the remote `splice_locked`:
+        - MUST send its `announcement_signatures` message.
 
 A recipient node:
-  - If the `short_channel_id` is NOT correct:
-    - SHOULD send a `warning` and close the connection, or send an
-      `error` and fail the channel.
+  - If the `short_channel_id` doesn't match one of its funding transactions:
+    - SHOULD send a `warning`.
   - If the `node_signature` OR the `bitcoin_signature` is NOT correct:
-    - MAY send a `warning` and close the connection, or send an
-      `error` and fail the channel.
+    - MAY send a `warning` and close the connection, or send an `error` and fail the channel.
   - If it has sent AND received a valid `announcement_signatures` message:
     - If the funding transaction has at least 6 confirmations:
       - SHOULD queue the `channel_announcement` message for its peers.
   - If it has not sent `channel_ready`:
     - SHOULD defer handling the `announcement_signatures` until after it has sent `channel_ready`.
+  - If it has not sent `splice_locked` for the transaction matching this `short_channel_id`:
+    - SHOULD defer handling the `announcement_signatures` until after it has sent `splice_locked`.
 
 ### Rationale
 
 Channels must not be announced before the funding transaction has enough
 confirmations, because a blockchain reorganization would otherwise invalidate
 the `short_channel_id`.
+
+When splicing is used, a `channel_announcement` is generated for every splice
+transaction once both sides have sent `splice_locked`. This lets the network
+know that the transaction spending a currently active channel is a splice and
+not a closing transaction, and this channel can still be used with its updated
+`short_channel_id`.
 
 ## The `channel_announcement` Message
 
@@ -164,9 +174,18 @@ The origin node:
   that the channel was opened within:
     - for the _Bitcoin blockchain_:
       - MUST set `chain_hash` value (encoded in hex) equal to `6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000`.
-  - MUST set `short_channel_id` to refer to the confirmed funding transaction,
-  as specified in [BOLT #2](02-peer-protocol.md#the-channel_ready-message).
-    - Note: the corresponding output MUST be a P2WSH, as described in [BOLT #3](03-transactions.md#funding-transaction-output).
+  - When announcing a channel creation:
+    - MUST set `short_channel_id` to refer to the confirmed funding transaction,
+      as specified in [BOLT #2](02-peer-protocol.md#the-channel_ready-message).
+  - When announcing a splice transaction:
+    - MUST set `short_channel_id` to refer to the confirmed splice transaction
+      for which `splice_locked` has been sent and received, as specified in
+      [BOLT #2](02-peer-protocol.md#the-splice_locked-message).
+    - SHOULD keep relaying payments that use the `short_channel_id`s of its
+      previous `channel_announcement`s.
+    - SHOULD send a new `channel_update` using the `short_channel_id` that
+      matches the latest `channel_announcement`.
+  - Note: the corresponding output MUST be a P2WSH, as described in [BOLT #3](03-transactions.md#funding-transaction-output).
   - MUST set `node_id_1` and `node_id_2` to the public keys of the two nodes
   operating the channel, such that `node_id_1` is the lexicographically-lesser of the
   two compressed keys sorted in ascending lexicographic order.
@@ -254,9 +273,11 @@ optional) features will have _odd_ feature bits, while incompatible features
 will have _even_ feature bits
 (["It's OK to be odd!"](00-introduction.md#glossary-and-terminology-guide)).
 
-A delay of 12 blocks is used when forgetting a channel on funding output spend
-as to permit a new `channel_announcement` to propagate which indicates this
-channel was spliced.
+A delay of 12 blocks is used when forgetting a channel after detecting that it
+has been spent: this can allow a new `channel_announcement` to propagate to
+indicate that this channel was spliced and not closed. Thanks to this delay,
+payments can still be relayed on the channel while the splice transaction is
+waiting for enough confirmations.
 
 ## The `node_announcement` Message
 

--- a/09-features.md
+++ b/09-features.md
@@ -53,6 +53,7 @@ The Context column decodes as follows:
 | 48/49 | `option_payment_metadata`         | Payment metadata in tlv record                            | 9        |                             | [BOLT #11](11-payment-encoding.md#tagged-fields)                      |
 | 50/51 | `option_zeroconf`                 | Understands zeroconf channel types                        | IN       | `option_scid_alias`         | [BOLT #2][bolt02-channel-ready]                                       |
 | 60/61 | `option_simple_close`             | Simplified closing negotiation                            | IN       | `option_shutdown_anysegwit` | [BOLT #2][bolt02-simple-close]                                        |
+| 62/63 | `option_splice`                   | Allows replacing the funding transaction with a new one   | IN       |                             | [BOLT #2](02-peer-protocol.md#channel-splicing)                       |
 
 ## Requirements
 

--- a/bolt02/splicing-test.md
+++ b/bolt02/splicing-test.md
@@ -1,0 +1,744 @@
+# Splicing Tests
+
+This file details various [splicing](../02-peer-protocol.md#channel-splicing) protocol flows.
+We detail the exact flow of messages for each scenario, and highlight several edge cases that must be correctly handled by implementations.
+
+## Table of Contents
+
+* [Terminology](#terminology)
+* [Test Vectors](#test-vectors)
+  * [Successful single splice](#successful-single-splice)
+  * [Multiple splices with concurrent `splice_locked`](#multiple-splices-with-concurrent-splice_locked)
+  * [Disconnection with one side sending `commit_sig`](#disconnection-with-one-side-sending-commit_sig)
+  * [Disconnection with both sides sending `commit_sig`](#disconnection-with-both-sides-sending-commit_sig)
+  * [Disconnection with one side sending `tx_signatures`](#disconnection-with-one-side-sending-tx_signatures)
+  * [Disconnection with both sides sending `tx_signatures`](#disconnection-with-both-sides-sending-tx_signatures)
+  * [Disconnection with both sides sending `tx_signatures` and channel updates](#disconnection-with-both-sides-sending-tx_signatures-and-channel-updates)
+  * [Disconnection with concurrent `splice_locked`](#disconnection-with-concurrent-splice_locked)
+
+## Terminology
+
+We call "active commitments" the set of valid commitment transactions to which updates (`update_add_htlc`, `update_fulfill_htlc`, `update_fail_htlc`, `update_fail_malformed_htlc`, `update_fee`) must be applied.
+While a funding transaction is not locked (ie `splice_locked` hasn't been exchanged), updates must be valid for all active commitments.
+
+When representing active commitments, we will only draw the corresponding funding transactions for simplicity.
+The related commitment transaction simply spends that funding transaction.
+
+For example, the following diagram displays the active commitments when we have an unconfirmed splice (`FundingTx2a`) and 2 RBF attempts for that splice (`FundingTx2b` and `FundingTx2c`).
+We thus have 4 active commitments:
+
+* the commitment spending `FundingTx1`
+* the commitments spending each splice transaction (`FundingTx2a`, `FundingTx2b` and `FundingTx2c`)
+
+```text
++------------+                +-------------+
+| FundingTx1 |--------+------>| FundingTx2a |
++------------+        |       +-------------+
+                      |
+                      |       +-------------+
+                      +------>| FundingTx2b |
+                      |       +-------------+
+                      |
+                      |       +-------------+
+                      +------>| FundingTx2c |
+                              +-------------+
+```
+
+**Peers must always agree on the set of active commitments**, otherwise one side will expect signatures that the other side will not send, which will lead to force-closing the channel.
+
+## Test Vectors
+
+In the protocol flows below, we omit the `interactive-tx` messages that build the transaction.
+The only `interactive-tx` messages we explicitly list are the consecutive `tx_complete` that mark the end of the `interactive-tx` construction.
+
+We also assume that both peers use the same `commitment_number` for simplicity.
+
+### Successful single splice
+
+Let's warm up with the simplest possible flow: a splice transaction that confirms without any disconnection.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |                              | The channel is no longer quiescent at that point.
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |       update_add_htlc        | Alice and Bob use the channel while the splice transaction is unconfirmed.
+     |----------------------------->|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 11
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |        splice_locked         | The splice transaction confirms.
+     |----------------------------->|
+     |        splice_locked         |
+     |<-----------------------------|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 11
+     |                              |    +------------+
+     |                              |    | FundingTx2 |
+     |                              |    +------------+
+     |                              | 
+     |       update_add_htlc        | Alice and Bob can use the channel and forget the previous FundingTx1.
+     |----------------------------->|
+     |         commit_sig           |
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         commit_sig           |
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 12
+     |                              |    +------------+
+     |                              |    | FundingTx2 |
+     |                              |    +------------+
+```
+
+### Multiple splices with concurrent `splice_locked`
+
+Since nodes have different views of the blockchain, they may send `splice_locked` at slightly different times.
+Moreover, nodes may send `splice_locked` concurrently with other channel updates, in which case they will receive some `commit_sig` messages for obsolete commitments.
+This is fine: nodes know how many `commit_sig` messages to expect thanks to the `batch_size` field, and they can simply ignore `commit_sig` messages for which the `funding_txid` cannot be found in the active commitments.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +-------------+
+     |                              |    | FundingTx1 |------->| FundingTx2a |
+     |                              |    +------------+        +-------------+
+     |                              |
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          tx_init_rbf         | Alice RBFs the splice attempt.
+     |----------------------------->|
+     |          tx_ack_rbf          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +-------------+
+     |                              |    | FundingTx1 |---+--->| FundingTx2a |
+     |                              |    +------------+   |    +-------------+
+     |                              |                     |
+     |                              |                     |    +-------------+
+     |                              |                     +--->| FundingTx2b |
+     |                              |                          +-------------+
+     |                              |
+     |       update_add_htlc        | Alice and Bob use the channel while the splice transactions are unconfirmed.
+     |----------------------------->|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         commit_sig           | batch_size = 3, funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | batch_size = 3, funding_txid = FundingTx2a, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | batch_size = 3, funding_txid = FundingTx2b, commitment_number = 11
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 3, funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 3, funding_txid = FundingTx2a, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 3, funding_txid = FundingTx2b, commitment_number = 11
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 11
+     |                              |    +------------+        +-------------+
+     |                              |    | FundingTx1 |---+--->| FundingTx2a |
+     |                              |    +------------+   |    +-------------+
+     |                              |                     |
+     |                              |                     |    +-------------+
+     |                              |                     +--->| FundingTx2b |
+     |                              |                          +-------------+
+     |                              |
+     |        splice_locked         | splice_txid = FundingTx2a
+     |----------------------------->|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         commit_sig           | batch_size = 3, funding_txid = FundingTx1, commitment_number = 12 -> this message will be ignored by Bob since FundingTx2a will be locked before the end of the batch
+     |----------------------------->|
+     |        splice_locked         | splice_txid = FundingTx2a
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 3, funding_txid = FundingTx2a, commitment_number = 12
+     |----------------------------->|
+     |         commit_sig           | batch_size = 3, funding_txid = FundingTx2b, commitment_number = 12 -> this message can be ignored by Bob since FundingTx2a has been locked
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         commit_sig           |
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 12
+     |                              |    +-------------+
+     |                              |    | FundingTx2b |
+     |                              |    +-------------+
+```
+
+### Disconnection with one side sending `commit_sig`
+
+In this scenario, a disconnection happens when one side has sent `commit_sig` but not the other.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before receiving Bob's tx_complete:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |       X----------------------|
+     |         commit_sig           |
+     |       X----------------------|
+     |                              | Active commitments for Alice:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+
+     |                              |    | FundingTx1 |
+     |                              |    +------------+
+     |                              | 
+     |                              | Active commitments for Bob:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 10, next_revocation_number = 10
+     |<-----------------------------|
+     |           tx_abort           |
+     |----------------------------->|
+     |           tx_abort           |
+     |<-----------------------------|
+     |                              | Bob can safely forget the splice attempt because he hasn't sent tx_signatures.
+     |                              | Active commitments for Alice and Bob:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+
+     |                              |    | FundingTx1 |
+     |                              |    +------------+
+```
+
+### Disconnection with both sides sending `commit_sig`
+
+In this scenario, a disconnection happens when both sides have sent `commit_sig`.
+They are able to resume the signatures exchange on reconnection.
+In this example, Bob is supposed to send `tx_signatures` first.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before receiving Bob's commit_sig:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |--------------------X         |
+     |         commit_sig           |
+     |       X----------------------|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 10, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 10, next_revocation_number = 10
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+```
+
+### Disconnection with one side sending `tx_signatures`
+
+In this scenario, a disconnection happens when one side has sent `tx_signatures` but not the other.
+They are able to resume the signatures exchange on reconnection.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before receiving Bob's tx_signatures:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |       X----------------------|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |<-----------------------------|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+```
+
+### Disconnection with both sides sending `tx_signatures`
+
+In this scenario, a disconnection happens when both sides have sent `tx_signatures`, but one side has not received it.
+They are able to resume the signatures exchange on reconnection.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before Bob receives her tx_signatures:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------X       |
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+```
+
+### Disconnection with both sides sending `tx_signatures` and channel updates
+
+In this scenario, a disconnection happens when both sides have sent `tx_signatures`, but one side has not received it.
+The second signer also sent a new signature for additional changes to apply after their `tx_signatures`.
+They are able to resume the signatures exchange on reconnection and retransmit new updates.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before Bob receives her tx_signatures and new updates:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------X       |
+     |       update_add_htlc        |
+     |----------------------X       |
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |----------------------X       |
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |----------------------X       |
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 11
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+```
+
+### Disconnection with concurrent `splice_locked`
+
+In this scenario, disconnections happen while nodes are exchanging `splice_locked`.
+The `splice_locked` message must be retransmitted on reconnection until new commitments have been signed.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before Bob receives her splice_locked:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |        splice_locked         |
+     |---------------------X        |
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |<-----------------------------|
+     |        splice_locked         |
+     |----------------------------->|
+     |        splice_locked         |
+     |       X----------------------|
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |<-----------------------------|
+     |        splice_locked         |
+     |----------------------------->|
+     |        splice_locked         |
+     |<-----------------------------|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+
+     |                              |    | FundingTx2 |
+     |                              |    +------------+
+     |       update_add_htlc        |
+     |----------------------X       |
+     |         commit_sig           |
+     |----------------------X       |
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |<-----------------------------|
+     |        splice_locked         |
+     |----------------------------->|
+     |        splice_locked         |
+     |<-----------------------------|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         commit_sig           |
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         commit_sig           |
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              |
+     |                              |    commitment_number = 11
+     |                              |    +------------+
+     |                              |    | FundingTx2 |
+     |                              |    +------------+
+     |                              |
+     |                              | A new commitment was signed, implicitly acknowledging splice_locked.
+     |                              | We thus don't need to retransmit splice_locked on reconnection.
+     |       update_add_htlc        |
+     |----------------------X       |
+     |         commit_sig           |
+     |----------------------X       |
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 12, next_revocation_number = 11
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 12, next_revocation_number = 11
+     |<-----------------------------|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         commit_sig           |
+     |----------------------------->|
+```


### PR DESCRIPTION
Clarifying the logic for `commitment_signed` batches are different and separate from individual `commitment_signed` messages used during interactive transaction protocol reestablishing.

This creates a clean separation from when `next_commitment_number` is being used to resend an individual `commitment_signed` message and when it is being used to resend a `commitment_signed` batch.

Without this change implementors don’t have clarity about whether a decremented `next_commitment_number` is meant to send an individual `commitment_signed` message, ``commitment_signed` batch, or both.