### PR TITLE
Update intro and add new reestablish tests to splicing-test.md

### DIFF
--- a/bolt02/splicing-test.md
+++ b/bolt02/splicing-test.md
@@ -792,7 +792,7 @@ Alice initiates a splice, but disconnects before Bob receives her commit_sigs fo
      |                              |
      |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
      |----------------------------->|
-     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
      |<-----------------------------|
      |         start_batch          | batch_size = 2
      |----------------------------->|
@@ -822,7 +822,7 @@ Alice initiates a splice, but disconnects before Bob receives her commit_sigs fo
 
 In this scenario, a disconnection happens when both sides have sent and received `tx_signatures`.
 Both signers also send new signatures for additional changes to apply after their `tx_signatures`.
-The first signer has received the second signers `revoke_and_ack` message for the channel update.
+The first signer has received the second signer's `revoke_and_ack` message for the channel update.
 They are able to resume the signature exchange on reconnection.
 
 ```text
@@ -833,7 +833,7 @@ Initial active commitments:
    | FundingTx1 |
    +------------+
 
-Alice initiates a splice, but disconnects before Bob receives her tx_signatures and new updates:
+Alice initiates a splice, but disconnects before she receives Bob's commit_sigs for new updates:
 
    Alice                           Bob
      |             stfu             |
@@ -885,7 +885,7 @@ Alice initiates a splice, but disconnects before Bob receives her tx_signatures 
      |                              |
      |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 11
      |----------------------------->|
-     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
      |<-----------------------------|
      |         start_batch          | batch_size = 2
      |<-----------------------------|
@@ -903,11 +903,11 @@ Alice initiates a splice, but disconnects before Bob receives her tx_signatures 
      |                              |    +------------+        +------------+
 ```
 
-### Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update; revoke_and_ack not received
+### Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update; `revoke_and_ack` not received
 
 In this scenario, a disconnection happens when both sides have sent and received `tx_signatures`.
 Both signers also send new signatures for additional changes to apply after their `tx_signatures`.
-The first signer has **not** received the second signers `revoke_and_ack` message for the channel update.
+The first signer has **not** received the second signer's `revoke_and_ack` message for the channel update.
 They are able to resume the signature exchange on reconnection.
 
 ```text
@@ -918,7 +918,7 @@ Initial active commitments:
    | FundingTx1 |
    +------------+
 
-Alice initiates a splice, but disconnects before Bob receives her tx_signatures and new updates:
+Alice initiates a splice, but disconnects before Bob receives her revoke_and_ack and commit_sigs for new updates:
 
    Alice                           Bob
      |             stfu             |
@@ -970,7 +970,7 @@ Alice initiates a splice, but disconnects before Bob receives her tx_signatures 
      |                              |
      |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
      |----------------------------->|
-     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
      |<-----------------------------|
      |       revoke_and_ack         |
      |<-----------------------------|

--- a/bolt02/splicing-test.md
+++ b/bolt02/splicing-test.md
@@ -16,9 +16,8 @@ We detail the exact flow of messages for each scenario, and highlight several ed
   * [Disconnection with both sides sending `tx_signatures` and channel updates](#disconnection-with-both-sides-sending-tx_signatures-and-channel-updates)
   * [Disconnection with concurrent `splice_locked`](#disconnection-with-concurrent-splice_locked)
   * [Disconnection after exchanging `tx_signatures` and one side sends `commit_sig` for channel update](#disconnection-after-exchanging-tx_signatures-and-one-side-sends-commit_sig-for-channel-update)
-  * [Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update](#disconnection-after-exchanging-tx_signatures-and-both-sides-send-commit_sig-for-channel-update)
   * [Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update; `revoke_and_ack` not received](#disconnection-after-exchanging-tx_signatures-and-both-sides-send-commit_sig-for-channel-update-revoke_and_ack-not-received)
-
+  * [Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update](#disconnection-after-exchanging-tx_signatures-and-both-sides-send-commit_sig-for-channel-update)
 ## Terminology
 
 We call "active commitments" the set of valid commitment transactions to which updates (`update_add_htlc`, `update_fulfill_htlc`, `update_fail_htlc`, `update_fail_malformed_htlc`, `update_fee`) must be applied.
@@ -820,91 +819,6 @@ Alice initiates a splice, but disconnects before Bob receives her commit_sigs fo
      |                              |    +------------+        +------------+
 ```
 
-### Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update
-
-In this scenario, a disconnection happens when both sides have sent and received `tx_signatures`.
-Both signers also send new signatures for additional changes to apply after their `tx_signatures`.
-The first signer has received the second signer's `revoke_and_ack` message for the channel update.
-They are able to resume the signature exchange on reconnection.
-
-```text
-Initial active commitments:
-
-   commitment_number = 10
-   +------------+
-   | FundingTx1 |
-   +------------+
-
-Alice initiates a splice, but disconnects before she receives Bob's commit_sigs for new updates:
-
-   Alice                           Bob
-     |             stfu             |
-     |----------------------------->|
-     |             stfu             |
-     |<-----------------------------|
-     |          splice_init         |
-     |----------------------------->|
-     |          splice_ack          |
-     |<-----------------------------|
-     |                              |
-     |       <interactive-tx>       |
-     |<---------------------------->|
-     |                              |
-     |         tx_complete          |
-     |----------------------------->|
-     |         tx_complete          |
-     |<-----------------------------|
-     |         commit_sig           |
-     |----------------------------->|
-     |         commit_sig           |
-     |<-----------------------------|
-     |        tx_signatures         |
-     |<-----------------------------|
-     |        tx_signatures         |
-     |----------------------------->|
-     |       update_add_htlc        |
-     |----------------------------->|
-     |         start_batch          | batch_size = 2
-     |----------------------------->|
-     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
-     |----------------------------->|
-     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
-     |----------------------------->|
-     |       revoke_and_ack         |
-     |<-----------------------------|
-     |         start_batch          | batch_size = 2
-     |       X----------------------|
-     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
-     |       X----------------------|
-     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
-     |       X----------------------|
-     |                              | Active commitments:
-     |                              | 
-     |                              |    commitment_number = 10
-     |                              |    +------------+        +------------+
-     |                              |    | FundingTx1 |------->| FundingTx2 |
-     |                              |    +------------+        +------------+
-     |                              |
-     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 11
-     |----------------------------->|
-     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
-     |<-----------------------------|
-     |         start_batch          | batch_size = 2
-     |<-----------------------------|
-     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
-     |<-----------------------------|
-     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
-     |<-----------------------------|
-     |       revoke_and_ack         |
-     |----------------------------->|
-     |                              | Active commitments:
-     |                              | 
-     |                              |    commitment_number = 11
-     |                              |    +------------+        +------------+
-     |                              |    | FundingTx1 |------->| FundingTx2 |
-     |                              |    +------------+        +------------+
-```
-
 ### Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update; `revoke_and_ack` not received
 
 In this scenario, a disconnection happens when both sides have sent and received `tx_signatures`.
@@ -975,6 +889,91 @@ Alice initiates a splice, but disconnects before Bob receives her revoke_and_ack
      |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
      |<-----------------------------|
      |       revoke_and_ack         |
+     |<-----------------------------|
+     |         start_batch          | batch_size = 2
+     |<-----------------------------|
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 11
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+```
+
+### Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update
+
+In this scenario, a disconnection happens when both sides have sent and received `tx_signatures`.
+Both signers also send new signatures for additional changes to apply after their `tx_signatures`.
+The first signer has received the second signer's `revoke_and_ack` message for the channel update.
+They are able to resume the signature exchange on reconnection.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before she receives Bob's commit_sigs for new updates:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         start_batch          | batch_size = 2
+     |----------------------------->|
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         start_batch          | batch_size = 2
+     |       X----------------------|
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |       X----------------------|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
+     |       X----------------------|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 11
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
      |<-----------------------------|
      |         start_batch          | batch_size = 2
      |<-----------------------------|

--- a/bolt02/splicing-test.md
+++ b/bolt02/splicing-test.md
@@ -53,9 +53,15 @@ The only `interactive-tx` messages we explicitly list are the consecutive `tx_co
 
 We also assume that both peers use the same `commitment_number` for simplicity.
 
+Comprehensive testing should include:
+* Splice-in, Splice-out and their sequential combinations.
+* Peers that have sufficient balance after the initial funding transaction.
+* Peers that have sufficient balance via htlcs.
+* Peers with different `commitment_number`.
+
 ### Successful single splice
 
-Let's warm up with the simplest possible flow: a splice transaction that confirms without any disconnection.
+Let's warm up with the simplest possible flow: a splice transaction that confirms without any disconnection. This flow should be tested for different scenarios, such as:
 
 ```text
 Initial active commitments:

--- a/bolt02/splicing-test.md
+++ b/bolt02/splicing-test.md
@@ -15,6 +15,9 @@ We detail the exact flow of messages for each scenario, and highlight several ed
   * [Disconnection with both sides sending `tx_signatures`](#disconnection-with-both-sides-sending-tx_signatures)
   * [Disconnection with both sides sending `tx_signatures` and channel updates](#disconnection-with-both-sides-sending-tx_signatures-and-channel-updates)
   * [Disconnection with concurrent `splice_locked`](#disconnection-with-concurrent-splice_locked)
+  * [Disconnection after exchanging `tx_signatures` and one side sends `commit_sig` for channel update](#disconnection-after-exchanging-tx_signatures-and-one-side-sends-commit_sig-for-channel-update)
+  * [Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update](#disconnection-after-exchanging-tx_signatures-and-both-sides-send-commit_sig-for-channel-update)
+  * [Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update; revoke_and_ack not received](#disconnection-after-exchanging-tx_signatures-and-both-sides-send-commit_sig-for-channel-update-revoke_and_ack-not-received)
 
 ## Terminology
 
@@ -729,4 +732,242 @@ Alice initiates a splice, but disconnections happen when exchanging splice_locke
      |<-----------------------------|
      |       revoke_and_ack         |
      |----------------------------->|
+```
+     
+### Disconnection after exchanging `tx_signatures` and one side sends `commit_sig` for channel update
+
+In this scenario, a disconnection happens when both sides have sent and received `tx_signatures`.
+The second signer also sent a new signature for additional changes to apply after their `tx_signatures`.
+They are able to resume the signature exchange on reconnection and continue with the `commit_sig` exchange.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before Bob receives her commit_sigs for new updates:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |----------------------X       |
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |----------------------X       |
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 11
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+```
+
+### Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update
+
+In this scenario, a disconnection happens when both sides have sent and received `tx_signatures`.
+Both signers also send new signatures for additional changes to apply after their `tx_signatures`.
+The first signer has received the second signers `revoke_and_ack` message for the channel update.
+They are able to resume the signature exchange on reconnection.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before Bob receives her tx_signatures and new updates:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |       X----------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |       X----------------------|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 11
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 11
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+```
+
+### Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update; revoke_and_ack not received
+
+In this scenario, a disconnection happens when both sides have sent and received `tx_signatures`.
+Both signers also send new signatures for additional changes to apply after their `tx_signatures`.
+The first signer has **not** received the second signers `revoke_and_ack` message for the channel update.
+They are able to resume the signature exchange on reconnection.
+
+```text
+Initial active commitments:
+
+   commitment_number = 10
+   +------------+
+   | FundingTx1 |
+   +------------+
+
+Alice initiates a splice, but disconnects before Bob receives her tx_signatures and new updates:
+
+   Alice                           Bob
+     |             stfu             |
+     |----------------------------->|
+     |             stfu             |
+     |<-----------------------------|
+     |          splice_init         |
+     |----------------------------->|
+     |          splice_ack          |
+     |<-----------------------------|
+     |                              |
+     |       <interactive-tx>       |
+     |<---------------------------->|
+     |                              |
+     |         tx_complete          |
+     |----------------------------->|
+     |         tx_complete          |
+     |<-----------------------------|
+     |         commit_sig           |
+     |----------------------------->|
+     |         commit_sig           |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |<-----------------------------|
+     |        tx_signatures         |
+     |----------------------------->|
+     |       update_add_htlc        |
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |----------------------------->|
+     |       revoke_and_ack         |
+     |       X----------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |       X----------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |       X----------------------|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 10
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
+     |                              |
+     |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
+     |----------------------------->|
+     |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |<-----------------------------|
+     |       revoke_and_ack         |
+     |----------------------------->|
+     |                              | Active commitments:
+     |                              | 
+     |                              |    commitment_number = 11
+     |                              |    +------------+        +------------+
+     |                              |    | FundingTx1 |------->| FundingTx2 |
+     |                              |    +------------+        +------------+
 ```

--- a/bolt02/splicing-test.md
+++ b/bolt02/splicing-test.md
@@ -777,9 +777,11 @@ Alice initiates a splice, but disconnects before Bob receives her commit_sigs fo
      |----------------------------->|
      |       update_add_htlc        |
      |----------------------------->|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |         start_batch          | batch_size = 2
      |----------------------X       |
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |----------------------X       |
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
      |----------------------X       |
      |                              | Active commitments:
      |                              | 
@@ -792,15 +794,19 @@ Alice initiates a splice, but disconnects before Bob receives her commit_sigs fo
      |----------------------------->|
      |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
      |<-----------------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |         start_batch          | batch_size = 2
      |----------------------------->|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
      |----------------------------->|
      |       revoke_and_ack         |
      |<-----------------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |         start_batch          | batch_size = 2
      |<-----------------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
      |<-----------------------------|
      |       revoke_and_ack         |
      |----------------------------->|
@@ -856,15 +862,19 @@ Alice initiates a splice, but disconnects before Bob receives her tx_signatures 
      |----------------------------->|
      |       update_add_htlc        |
      |----------------------------->|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |         start_batch          | batch_size = 2
      |----------------------------->|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
      |----------------------------->|
      |       revoke_and_ack         |
      |<-----------------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |         start_batch          | batch_size = 2
      |       X----------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |       X----------------------|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
      |       X----------------------|
      |                              | Active commitments:
      |                              | 
@@ -877,9 +887,11 @@ Alice initiates a splice, but disconnects before Bob receives her tx_signatures 
      |----------------------------->|
      |      channel_reestablish     | next_funding_txid = FundingTx2, next_commitment_number = 11, next_revocation_number = 10
      |<-----------------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |         start_batch          | batch_size = 2
      |<-----------------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
      |<-----------------------------|
      |       revoke_and_ack         |
      |----------------------------->|
@@ -935,15 +947,19 @@ Alice initiates a splice, but disconnects before Bob receives her tx_signatures 
      |----------------------------->|
      |       update_add_htlc        |
      |----------------------------->|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |         start_batch          | batch_size = 2
      |----------------------------->|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |----------------------------->|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
      |----------------------------->|
      |       revoke_and_ack         |
      |       X----------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |         start_batch          | batch_size = 2
      |       X----------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |       X----------------------|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
      |       X----------------------|
      |                              | Active commitments:
      |                              | 
@@ -958,9 +974,11 @@ Alice initiates a splice, but disconnects before Bob receives her tx_signatures 
      |<-----------------------------|
      |       revoke_and_ack         |
      |<-----------------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx1, commitment_number = 11
+     |         start_batch          | batch_size = 2
      |<-----------------------------|
-     |         commit_sig           | batch_size = 2, funding_txid = FundingTx2, commitment_number = 11
+     |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11
+     |<-----------------------------|
+     |         commit_sig           | funding_txid = FundingTx2, commitment_number = 11
      |<-----------------------------|
      |       revoke_and_ack         |
      |----------------------------->|

--- a/bolt02/splicing-test.md
+++ b/bolt02/splicing-test.md
@@ -17,7 +17,7 @@ We detail the exact flow of messages for each scenario, and highlight several ed
   * [Disconnection with concurrent `splice_locked`](#disconnection-with-concurrent-splice_locked)
   * [Disconnection after exchanging `tx_signatures` and one side sends `commit_sig` for channel update](#disconnection-after-exchanging-tx_signatures-and-one-side-sends-commit_sig-for-channel-update)
   * [Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update](#disconnection-after-exchanging-tx_signatures-and-both-sides-send-commit_sig-for-channel-update)
-  * [Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update; revoke_and_ack not received](#disconnection-after-exchanging-tx_signatures-and-both-sides-send-commit_sig-for-channel-update-revoke_and_ack-not-received)
+  * [Disconnection after exchanging `tx_signatures` and both sides send `commit_sig` for channel update; `revoke_and_ack` not received](#disconnection-after-exchanging-tx_signatures-and-both-sides-send-commit_sig-for-channel-update-revoke_and_ack-not-received)
 
 ## Terminology
 
@@ -794,6 +794,8 @@ Alice initiates a splice, but disconnects before Bob receives her commit_sigs fo
      |----------------------------->|
      |      channel_reestablish     | next_funding_txid = null, next_commitment_number = 11, next_revocation_number = 10
      |<-----------------------------|
+     |       update_add_htlc        |
+     |----------------------------->|
      |         start_batch          | batch_size = 2
      |----------------------------->|
      |         commit_sig           | funding_txid = FundingTx1, commitment_number = 11


### PR DESCRIPTION
These changes are the result of running interop tests with clightning.  This PR suggests running variants of the happy path for splices and adds three new tests that rift on the reestablish tests.